### PR TITLE
official devices: Promote Nothing Phone (1) to android 14

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -39,6 +39,13 @@
             "supported_edition": [
                "gapps"
             ]
+         },
+         {
+            "name": "fourteen",
+            "xda_thread": "https://xdaforums.com/t/pixysos-v7-1-2-beta-5-1-for-nothing-phone-1-android-14.4637640/",
+            "supported_edition": [
+               "gapps"
+            ]
          }
       ]
    },

--- a/teams.json
+++ b/teams.json
@@ -226,7 +226,8 @@
          },
          {
             "bases": [
-               "thirteen"
+               "thirteen",
+	       "fourteen"
             ],
             "codename": "Spacewar"
          }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new device "fourteen" to the device list with a link to its XDA thread and information on the supported edition.
	- Updated the "Spacewar" team in the teams list with a new base "fourteen".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->