### PR TITLE
official_devices: Promote pixel 4 series to android 14

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -202,6 +202,13 @@
             "supported_edition": [
                "gapps"
             ]
+         },
+         {
+            "name": "fourteen",
+            "xda_thread": "https://xdaforums.com/t/pixysos-v7-1-2-beta-4-for-pixel-4-xl-android-14-motion-sense.4639899/",
+            "supported_edition": [
+               "gapps"
+            ]
          }
       ]
    },
@@ -242,6 +249,13 @@
          {
             "name": "thirteen",
             "xda_thread": "https://forum.xda-developers.com/t/official-pixysos-v6-3-3-for-pixel-4-xl-coral-android-13-qpr3.4618523/",
+            "supported_edition": [
+               "gapps"
+            ]
+         },
+         {
+            "name": "fourteen",
+            "xda_thread": "https://xdaforums.com/t/pixysos-v7-1-2-beta-3-for-pixel-4-flame-android-14-qpr1-motion-sense.4651194/",
             "supported_edition": [
                "gapps"
             ]

--- a/teams.json
+++ b/teams.json
@@ -214,13 +214,15 @@
          },
          {
             "bases": [
-               "thirteen"
+               "thirteen",
+               "fourteen"
             ],
             "codename": "coral"
          },
          {
             "bases": [
-               "thirteen"
+               "thirteen",
+               "fourteen"
             ],
             "codename": "flame"
          },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new device "fourteen" in the devices listing, complete with resources and supported editions.
	- Expanded team bases in the teams listing to include the new base "fourteen" for teams with codenames "coral" and "flame."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->